### PR TITLE
Added to the README.md: Example usage on Ubuntu 16.04 Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,13 @@ See `requirements.txt` file
 
 1. https://raw.githubusercontent.com/fastlyhoo/wpt_h1vsh2/master/wpt_h1vsh2.py
 2. Add a snippet to the VERY beginning (line 1) of the script since you're not running a window manager (X11) and matlabplot will error on you because it assumes you are
-```
-############## BEGIN SERVER-COMPATIBILITY BLOCK ############
-# Add this to the beginning of wpt_h1vsh2.py to use it on a server (without X11)
-import matplotlib
-matplotlib.use('Agg')
-############## END SERVER-COMPATIBILITY BLOCK ##############
-```
+  ```
+  ############## BEGIN SERVER-COMPATIBILITY BLOCK ############
+  # Add this to the beginning of wpt_h1vsh2.py to use it on a server (without X11)
+  import matplotlib
+  matplotlib.use('Agg')
+  ############## END SERVER-COMPATIBILITY BLOCK ##############
+  ```
 3. apt-get install python-pip python-tk
 4. pip install -U pip setuptools
 5. pip install matplotlib requests seaborn

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ See `requirements.txt` file
 
 1. https://raw.githubusercontent.com/fastlyhoo/wpt_h1vsh2/master/wpt_h1vsh2.py
 2. Add a snippet to the VERY beginning (line 1) of the script since you're not running a window manager (X11) and matlabplot will error on you because it assumes you are
+
         ```
         ############## BEGIN SERVER-COMPATIBILITY BLOCK ############
         # Add this to the beginning of wpt_h1vsh2.py to use it on a server (without X11)
@@ -58,6 +59,7 @@ See `requirements.txt` file
         matplotlib.use('Agg')
         ############## END SERVER-COMPATIBILITY BLOCK ##############
         ```
+
 3. apt-get install python-pip python-tk
 4. pip install -U pip setuptools
 5. pip install matplotlib requests seaborn

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ See `requirements.txt` file
 
 ## Example usage on Ubuntu 16.04 Server (No X11)
 
-1. https://raw.githubusercontent.com/fastlyhoo/wpt_h1vsh2/master/wpt_h1vsh2.py
+1. Run **wget https://raw.githubusercontent.com/fastlyhoo/wpt_h1vsh2/master/wpt_h1vsh2.py**
 2. Add a snippet to the VERY beginning (line 1) of the script since you're not running a window manager (X11) and matlabplot will error on you because it assumes you are
 
         ############## BEGIN SERVER-COMPATIBILITY BLOCK ############

--- a/README.md
+++ b/README.md
@@ -52,13 +52,11 @@ See `requirements.txt` file
 1. https://raw.githubusercontent.com/fastlyhoo/wpt_h1vsh2/master/wpt_h1vsh2.py
 2. Add a snippet to the VERY beginning (line 1) of the script since you're not running a window manager (X11) and matlabplot will error on you because it assumes you are
 
-        ```
         ############## BEGIN SERVER-COMPATIBILITY BLOCK ############
         # Add this to the beginning of wpt_h1vsh2.py to use it on a server (without X11)
         import matplotlib
         matplotlib.use('Agg')
         ############## END SERVER-COMPATIBILITY BLOCK ##############
-        ```
 
 3. apt-get install python-pip python-tk
 4. pip install -U pip setuptools

--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ See `requirements.txt` file
 
 1. https://raw.githubusercontent.com/fastlyhoo/wpt_h1vsh2/master/wpt_h1vsh2.py
 2. Add a snippet to the VERY beginning (line 1) of the script since you're not running a window manager (X11) and matlabplot will error on you because it assumes you are
-
 ```
 ############## BEGIN SERVER-COMPATIBILITY BLOCK ############
 # Add this to the beginning of wpt_h1vsh2.py to use it on a server (without X11)
@@ -59,7 +58,6 @@ import matplotlib
 matplotlib.use('Agg')
 ############## END SERVER-COMPATIBILITY BLOCK ##############
 ```
-
 3. apt-get install python-pip python-tk
 4. pip install -U pip setuptools
 5. pip install matplotlib requests seaborn

--- a/README.md
+++ b/README.md
@@ -52,17 +52,17 @@ See `requirements.txt` file
 1. Run **wget https://raw.githubusercontent.com/fastlyhoo/wpt_h1vsh2/master/wpt_h1vsh2.py**
 2. Add a snippet to the VERY beginning (line 1) of the script since you're not running a window manager (X11) and matlabplot will error on you because it assumes you are
 
-    ############## BEGIN SERVER-COMPATIBILITY BLOCK ############
-    # Add this to the beginning of wpt_h1vsh2.py to use it on a server (without X11)
-    import matplotlib
-    matplotlib.use('Agg')
-    ############## END SERVER-COMPATIBILITY BLOCK ##############
+        ############## BEGIN SERVER-COMPATIBILITY BLOCK ############
+        # Add this to the beginning of wpt_h1vsh2.py to use it on a server (without X11)
+        import matplotlib
+        matplotlib.use('Agg')
+        ############## END SERVER-COMPATIBILITY BLOCK ##############
 
 3. apt-get install python-pip python-tk
 4. pip install -U pip setuptools
 5. pip install matplotlib requests seaborn
 6. get your api key from [https://www.webpagetest.org/getkey.php](https://www.webpagetest.org/getkey.php) and copy it into your wpt_h1vsh2.py like:
 
-    WPT_KEY = 'A.2348902482728395072'
+        WPT_KEY = 'A.2348902482728395072'
 
 7. Run **python wpt_h1vsh2.py** and enter your values when prompted

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # wpt_h1vsh2
-This is a simple script which uses [webpagetest](https://www.webpagetest.org/) to compare core performance metrics of a page with HTTP/1.1 and HTTP/2. The script will default to using public webpagetest ([API key needed](https://www.webpagetest.org/getkey.php)), but can be configured to use a [private instance](https://sites.google.com/a/webpagetest.org/docs/private-instances). 
+This is a simple script which uses [webpagetest](https://www.webpagetest.org/) to compare core performance metrics of a page with HTTP/1.1 and HTTP/2. The script will default to using public webpagetest ([API key needed](https://www.webpagetest.org/getkey.php)), but can be configured to use a [private instance](https://sites.google.com/a/webpagetest.org/docs/private-instances).
 
 Private instances are recommended since they can perform tests with many runs (public webpagetest limits each test to 9 runs).
 
@@ -46,3 +46,22 @@ Outside of catching some very basic errors, there's not a lot of error checking 
 
 ## Requirements
 See `requirements.txt` file
+
+## Example usage on Ubuntu 16.04 Server (No X11)
+
+1. https://raw.githubusercontent.com/fastlyhoo/wpt_h1vsh2/master/wpt_h1vsh2.py
+2. Add a snippet to the VERY beginning (line 1) of the script since you're not running a window manager (X11) and matlabplot will error on you because it assumes you are
+
+```
+############## BEGIN SERVER-COMPATIBILITY BLOCK ############
+# Add this to the beginning of wpt_h1vsh2.py to use it on a server (without X11)
+import matplotlib
+matplotlib.use('Agg')
+############## END SERVER-COMPATIBILITY BLOCK ##############
+```
+
+3. apt-get install python-pip python-tk
+4. pip install -U pip setuptools
+5. pip install matplotlib requests seaborn
+6. get your api key from [https://www.webpagetest.org/getkey.php](https://www.webpagetest.org/getkey.php) and copy it into your wpt_h1vsh2.py (example: WPT_KEY = 'A.2348902482728395072')
+7. Run **python wpt_h1vsh2.py** and enter your values when prompted

--- a/README.md
+++ b/README.md
@@ -52,14 +52,17 @@ See `requirements.txt` file
 1. Run **wget https://raw.githubusercontent.com/fastlyhoo/wpt_h1vsh2/master/wpt_h1vsh2.py**
 2. Add a snippet to the VERY beginning (line 1) of the script since you're not running a window manager (X11) and matlabplot will error on you because it assumes you are
 
-        ############## BEGIN SERVER-COMPATIBILITY BLOCK ############
-        # Add this to the beginning of wpt_h1vsh2.py to use it on a server (without X11)
-        import matplotlib
-        matplotlib.use('Agg')
-        ############## END SERVER-COMPATIBILITY BLOCK ##############
+    ############## BEGIN SERVER-COMPATIBILITY BLOCK ############
+    # Add this to the beginning of wpt_h1vsh2.py to use it on a server (without X11)
+    import matplotlib
+    matplotlib.use('Agg')
+    ############## END SERVER-COMPATIBILITY BLOCK ##############
 
 3. apt-get install python-pip python-tk
 4. pip install -U pip setuptools
 5. pip install matplotlib requests seaborn
-6. get your api key from [https://www.webpagetest.org/getkey.php](https://www.webpagetest.org/getkey.php) and copy it into your wpt_h1vsh2.py (example: WPT_KEY = 'A.2348902482728395072')
+6. get your api key from [https://www.webpagetest.org/getkey.php](https://www.webpagetest.org/getkey.php) and copy it into your wpt_h1vsh2.py like:
+
+    WPT_KEY = 'A.2348902482728395072'
+
 7. Run **python wpt_h1vsh2.py** and enter your values when prompted

--- a/README.md
+++ b/README.md
@@ -51,13 +51,13 @@ See `requirements.txt` file
 
 1. https://raw.githubusercontent.com/fastlyhoo/wpt_h1vsh2/master/wpt_h1vsh2.py
 2. Add a snippet to the VERY beginning (line 1) of the script since you're not running a window manager (X11) and matlabplot will error on you because it assumes you are
-  ```
-  ############## BEGIN SERVER-COMPATIBILITY BLOCK ############
-  # Add this to the beginning of wpt_h1vsh2.py to use it on a server (without X11)
-  import matplotlib
-  matplotlib.use('Agg')
-  ############## END SERVER-COMPATIBILITY BLOCK ##############
-  ```
+        ```
+        ############## BEGIN SERVER-COMPATIBILITY BLOCK ############
+        # Add this to the beginning of wpt_h1vsh2.py to use it on a server (without X11)
+        import matplotlib
+        matplotlib.use('Agg')
+        ############## END SERVER-COMPATIBILITY BLOCK ##############
+        ```
 3. apt-get install python-pip python-tk
 4. pip install -U pip setuptools
 5. pip install matplotlib requests seaborn


### PR DESCRIPTION
I wanted to run this script from my server with no X11 and ran into an error on the write_pdf call because the $DISPLAY environment is not set when X11 is not installed.

I updated my script with the referenced 2 lines of code and it worked well. Others might want to take advantage if they're on an Ubuntu 16.04 server.

Cheers,
Nanch

P.S. Here was the error reported:

  File "wpt_h1vsh2.py", line 217, in <module>
    rval = main()
  File "wpt_h1vsh2.py", line 203, in main
    write_pdf(output_pdf_file, plot_dict)
  File "wpt_h1vsh2.py", line 148, in write_pdf
    plt.figure(figsize=(8, 6))
  File "/usr/local/lib/python2.7/dist-packages/matplotlib/pyplot.py", line 535, in figure
    **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/matplotlib/backends/backend_tkagg.py", line 84, in new_figure_manager
    return new_figure_manager_given_figure(num, figure)
  File "/usr/local/lib/python2.7/dist-packages/matplotlib/backends/backend_tkagg.py", line 92, in new_figure_manager_given_figure
    window = Tk.Tk()
  File "/usr/lib/python2.7/lib-tk/Tkinter.py", line 1818, in **init**
    self.tk = _tkinter.create(screenName, baseName, className, interactive, wantobjects, useTk, sync, use)
_tkinter.TclError: no display name and no $DISPLAY environment variable
